### PR TITLE
Fix Cascade afterburner waterfall effect

### DIFF
--- a/GameData/FarFutureTechnologies/Parts/Engines/Fusion/fft-fusion-axial-zpinch-1.cfg
+++ b/GameData/FarFutureTechnologies/Parts/Engines/Fusion/fft-fusion-axial-zpinch-1.cfg
@@ -1489,7 +1489,7 @@ EFFECT
       FLOAT
       {
         floatName = _SpeedY
-        value = -5
+        value = 5
       }
       FLOAT
       {


### PR DESCRIPTION
The `_SpeedY` value on the `outerExhaust` effect for the Cascade engine in afterburning mode is negative, causing it to appear to flow backwards into the engine nozzle.  Changing it to positive fixes this.